### PR TITLE
[221119] [FE] 장바구니에서 주문완료하면 주문한 아이템만 장바구니에서 지워주는 기능 추가

### DIFF
--- a/src/views/cart/cart.js
+++ b/src/views/cart/cart.js
@@ -1,6 +1,10 @@
 import { getSavedItems, saveItems } from "../utils/localStorage.js";
 import { getPureDigit } from "../utils/useful_functions.js";
-import { isEmptyCart } from "../utils/cart.js";
+import {
+  isEmptyCart,
+  removeProductFromLocalDB,
+  adjustQuantityFromLocalDB,
+} from "../utils/cart.js";
 import { Keys } from "../constants/Keys.js";
 
 const shoppingbagList = document.querySelector(".shoppingbag-list");
@@ -13,19 +17,6 @@ const totalPrice = document.querySelector(".total-payment-price");
 const checkoutButton = document.querySelector(".checkout");
 
 const HIDDEN_CLASSNAME = "hidden";
-
-function removeProductFromDB(productId) {
-  let savedProducts = getSavedItems(Keys.CART_KEY);
-  savedProducts = savedProducts.filter((product) => String(product._id) !== String(productId));
-  return savedProducts;
-}
-
-function adjustQuantityFromDB(productId, quantity) {
-  const savedProducts = getSavedItems(Keys.CART_KEY);
-  const index = savedProducts.findIndex((x) => x._id === productId);
-  savedProducts[index].quantity = quantity;
-  saveItems(Keys.CART_KEY, savedProducts);
-}
 
 function showProduct(item) {
   let product = undefined;
@@ -107,7 +98,7 @@ function checkAllProducts(e) {
 
 function deleteProductFromCart(e) {
   const productDiv = e.target.parentElement.parentElement.parentElement;
-  let savedProducts = removeProductFromDB(productDiv.id);
+  let savedProducts = removeProductFromLocalDB(productDiv.id);
   productDiv.remove();
   saveItems(Keys.CART_KEY, savedProducts);
   if (isEmptyCart(savedProducts)) hideCheckout();
@@ -130,7 +121,7 @@ function deleteCheckedProducts() {
   const checkedItemList = getCheckedItems();
   checkedItemList.forEach((item) => {
     const productDiv = document.getElementById(item.id);
-    let savedProducts = removeProductFromDB(productDiv.id);
+    let savedProducts = removeProductFromLocalDB(productDiv.id);
     productDiv.remove();
     saveItems(Keys.CART_KEY, savedProducts);
     if (isEmptyCart(savedProducts)) hideCheckout();
@@ -143,7 +134,7 @@ function decreaseProductQuantity(e) {
   const price = decreaseDiv.parentElement.nextElementSibling;
   if (quantity.innerText > 1) {
     quantity.innerText -= 1;
-    adjustQuantityFromDB(decreaseDiv.id, quantity.innerText);
+    adjustQuantityFromLocalDB(decreaseDiv.id, quantity.innerText);
     setProductPrice(quantity.innerText, price);
   }
 }
@@ -153,7 +144,7 @@ function increaseProductQuantity(e) {
   const quantity = increaseDiv.previousElementSibling;
   const price = increaseDiv.parentElement.nextElementSibling;
   quantity.innerText = parseInt(quantity.innerText) + 1;
-  adjustQuantityFromDB(increaseDiv.id, quantity.innerText);
+  adjustQuantityFromLocalDB(increaseDiv.id, quantity.innerText);
   setProductPrice(quantity.innerText, price);
 }
 

--- a/src/views/utils/cart.js
+++ b/src/views/utils/cart.js
@@ -1,10 +1,23 @@
 import * as api from "../api.js";
-import { saveItems } from "../../utils/localStorage.js";
+import { getSavedItems, saveItems } from "../../utils/localStorage.js";
 import { Keys } from "../constants/Keys.js";
 import { ApiUrl } from "../constants/ApiUrl.js";
 
 function isEmptyCart(productsList) {
   return productsList == null || productsList.length === 0;
+}
+
+function removeProductFromLocalDB(productId) {
+  let cartProducts = getSavedItems(Keys.CART_KEY);
+  cartProducts = cartProducts.filter((product) => String(product._id) !== String(productId));
+  return cartProducts;
+}
+
+function adjustQuantityFromLocalDB(productId, quantity) {
+  const savedProducts = getSavedItems(Keys.CART_KEY);
+  const index = savedProducts.findIndex((x) => x._id === productId);
+  savedProducts[index].quantity = quantity;
+  saveItems(Keys.CART_KEY, savedProducts);
 }
 
 function refineDataForPatch(productsArr) {
@@ -35,4 +48,10 @@ async function updateCartInfoToDB(productsArr) {
   }
 }
 
-export { isEmptyCart, getCartInfoFromDB, updateCartInfoToDB };
+export {
+  isEmptyCart,
+  adjustQuantityFromLocalDB,
+  removeProductFromLocalDB,
+  getCartInfoFromDB,
+  updateCartInfoToDB,
+};


### PR DESCRIPTION
- [x]  장바구니에서 주문 페이지로 redirect 하기 직전 localStorage에 is-cart-order: true로 저장
- [x]  주문페이지에서 주문 post 요청 성공했을 때 is-cart-order: true면 지금 주문한 상품들 장바구니에서 삭제하기
    - [x]  localStorage에 담긴 장바구니 데이터 수정
    - [x]  해당작업 끝나면 order localStorage 비우고 is-cart-order: false로 바꾼 뒤 주문완료 페이지로 이동