### PR TITLE
[221127] [FE] 검색 시 input이 존재하지 않을 때 페이지에 머무는 기능 추가

### DIFF
--- a/src/views/template/header/header.js
+++ b/src/views/template/header/header.js
@@ -63,15 +63,15 @@ async function redirectPage() {
   });
 
   $(".company-logo").addEventListener("click", () => (window.location.href = "/"));
-  $(".search-button").addEventListener("click", () => (appendSearchModal()));
+  $(".search-button").addEventListener("click", () => appendSearchModal());
   $(".join").addEventListener("click", () => (window.location.href = "/join"));
   $(".login").addEventListener("click", () => (window.location.href = "/login"));
   $(".myPage").addEventListener("click", () => (window.location.href = "/myPage"));
   $("#eventProducts").addEventListener("click", () => (window.location.href = "/event-page"));
-  
+
   if (getCookieValue(Keys.TOKEN_KEY)) {
     const user = await get(ApiUrl.USER_INFORMATION);
-    
+
     user["role"] === "admin" ? loginAsAdmin() : loginAsUser();
     handleLogout();
 
@@ -134,12 +134,16 @@ function appendSearchModal() {
 </div>
 `;
   const bodyContainer = document.querySelector("body");
-  bodyContainer.insertAdjacentHTML('beforebegin', searchModalHTML);
+  bodyContainer.insertAdjacentHTML("beforebegin", searchModalHTML);
 
-  $('.modal-close-button').addEventListener('click', () => ($('.modal').remove()));
+  $(".modal-close-button").addEventListener("click", () => $(".modal").remove());
   $(".search-image").addEventListener("click", handleSearch);
-  $(".search-input").addEventListener('keydown', (e) => {
-    if(e.keyCode ==13){
+  $(".search-input").addEventListener("keydown", (e) => {
+    if (e.keyCode == 13) {
+      if (e.target.value == "") {
+        alert("검색어를 입력해주세요!");
+        window.location.assign();
+      }
       window.location.href = `/search/?keyword=${e.target.value}`;
     }
   });
@@ -149,6 +153,10 @@ function handleSearch(e) {
   e.preventDefault();
   const input = $(".search-input");
   const query = input.value;
+  if (query == "") {
+    alert("검색어를 입력해주세요!");
+    window.location.assign();
+  }
   window.location.href = `/search/?keyword=${query}`;
 }
 


### PR DESCRIPTION
검색 기능에서1. 엔터 2.검색버튼을 눌렀을 때 input 값이 없더라도 아무 상품을 보여주지 않는 페이지로 이동하였는데 그대로 검색 
모달 페이지에 머물며 alert 메세지를 띄우도록 기능을 추가함.

* 재웅님이 추가해주신 keydown 엔터 이벤트에도 적용하여 테스트하여 버그가 나지 않음을 확인함.