### PR TITLE
[221206] [FE] filter.css 수정 -> 다른 페이지들과 통일

### DIFF
--- a/src/views/filter/filter.css
+++ b/src/views/filter/filter.css
@@ -1,164 +1,167 @@
 /* body */
 .body-container {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    margin-top: 80px !important;
-    padding: 0 10vw 0 10vw !important;
-    transition: all 0.05s ease-in;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: 60px !important;
+  padding: 0 10vw 0 10vw !important;
+  transition: all 0.05s ease-in;
+}
+
+@media screen and (min-width: 1700px) {
+  .body-container {
+    padding: 0 15vw 0 15vw !important;
   }
-  
-  @media screen and (min-width: 1700px) {
-    .body-container {
-      padding: 0 15vw 0 15vw !important;
-    }
+}
+
+@media screen and (min-width: 1300px) and (max-width: 1700px) {
+  .body-container {
+    padding: 0 9vw 0 9vw !important;
   }
-  
-  @media screen and (min-width: 1300px) and (max-width: 1700px) {
-    .body-container {
-      padding: 0 9vw 0 9vw !important;
-    }
+}
+
+@media screen and (min-width: 1150px) and (max-width: 1300px) {
+  .body-container {
+    padding: 0 5vw 0 5vw !important;
   }
-  
-  @media screen and (min-width: 1150px) and (max-width: 1300px) {
-    .body-container {
-      padding: 0 5vw 0 5vw !important;
-    }
+}
+
+@media screen and (min-width: 885px) and (max-width: 1150px) {
+  .body-container {
+    padding: 0 1vw 0 1vw !important;
   }
-  
-  @media screen and (min-width: 885px) and (max-width: 1150px) {
-    .body-container {
-      padding: 0 1vw 0 1vw !important;
-    }
-  
-    .product-container-wrapper {
-      width: 25.5% !important;
-    }
-  
-    .product-content-container .content-title-wrapper {
-      font-size: var(--font-xl);
-    }
-  
-    .product-content-container .content-price {
-      font-size: var(--font-base);
-    }
-  }
-  
-  @media screen and (min-width: 680px) and (max-width: 885px) {
-    .product-container-wrapper {
-      width: 39.5% !important;
-    }
-  
-    .body-container {
-      padding: 0 0vw 0 0vw !important;
-    }
-  }
-  
-  @media screen and (max-width: 680px) {
-    .product-container-wrapper {
-      width: 50.5% !important;
-    }
-  
-    .body-container {
-      padding: 0 0vw 0 0vw !important;
-    }
-  }
-  
-  /* product */
+
   .product-container-wrapper {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    width: 21.5%;
+    width: 25.5% !important;
   }
-  
-  .product-container {
-    display: flex;
-    flex-direction: column;
-    margin: 0px 5px 65px 10px;
-    max-width: 390px;
-    user-select: none;
+
+  .product-content-container .content-title-wrapper {
+    font-size: var(--font-xl);
   }
-  
-  .product-container:hover {
-    cursor: pointer;
-  }
-  
-  .product-content-container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-  }
-  
-  .product-div-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-  
-  .product-div-container .product-image-wrapper {
-    display: flex;
-    justify-content: center;
-    max-height: 450px;
-  }
-  
-  .product-div-container .product-image-wrapper img {
-    object-fit: cover;
-    margin-bottom: 20px;
-    border-radius: 2%;
-    aspect-ratio: 4 / 5.5;
-    max-height: 380px;
-    min-height: 290px;
-    min-width: 180px;
-    transition: all 0.15s ease;
-  }
-  
-  .product-div-container .product-image-wrapper img:hover, .product-content-container:hover{
-    opacity: 0.75;
-  }
-  
-  /* product-content-container */
-  .product-content-container {
-    transition: all 0.15s ease;
-  }
-  
-  .content-title-wrapper {
-    color: #363636;
-    font-size: var(--font-xxl);
-    font-weight: 600;
-    line-height: 1.125;
-    margin-bottom: 8px;
-  }
-  
-  .content-container {
-    display: flex;
-    flex-direction: column;
-    font-weight: 400;
-    width: 100%;
+
+  .product-content-container .content-price {
     font-size: var(--font-base);
   }
-  
-  .content-container .content-price {
-    font-weight: 600;
+}
+
+@media screen and (min-width: 575px) and (max-width: 885px) {
+  .product-container-wrapper {
+    width: 39.5% !important;
   }
-  
-  .content-container .content-brandName {
-    display: flex;
-    flex-direction: row;
+
+  .body-container {
+    padding: 0 0vw 0 0vw !important;
   }
-  
-  .content-container .content-brandName p {
-    margin-right: 10px;
+}
+
+@media screen and (max-width: 575px) {
+  .product-container-wrapper {
+    width: 49.5% !important;
   }
-  
-  .none {
-    display: none;
+
+  .body-container {
+    padding: 0 0vw 0 0vw !important;
   }
-  
-  /* pagination */
-  .pagination-container .pagination-list {
-    gap: 1rem;
-    justify-content: center;
-  }
-  
+}
+
+/* product */
+.product-container-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  width: 21.5%;
+}
+
+.product-container {
+  display: flex;
+  flex-direction: column;
+  margin: 0px 5px 65px 10px;
+  max-width: 390px;
+  user-select: none;
+}
+
+.product-container:hover {
+  cursor: pointer;
+}
+
+.product-content-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.product-div-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.product-div-container .product-image-wrapper {
+  display: flex;
+  justify-content: center;
+  max-height: 450px;
+}
+
+.product-div-container .product-image-wrapper img {
+  object-fit: cover;
+  margin-bottom: 20px;
+  border-radius: 2%;
+  aspect-ratio: 4 / 5.5;
+  max-height: 380px;
+  min-width: 180px;
+  transition: all 0.15s ease;
+}
+
+.product-div-container .product-image-wrapper img:hover, .product-content-container:hover{
+  opacity: 0.75;
+}
+
+/* product-content-container */
+.product-content-container {
+  transition: all 0.15s ease;
+}
+
+.content-title-wrapper {
+  color: #363636;
+  font-size: var(--font-xxl);
+  font-weight: 600;
+  line-height: 1.125;
+  margin-bottom: 8px;
+}
+
+.content-container {
+  display: flex;
+  flex-direction: column;
+  font-weight: 400;
+  width: 100%;
+  font-size: var(--font-base);
+}
+
+.content-container .content-price {
+  font-weight: 600;
+}
+
+.content-container .content-brandName {
+  display: flex;
+  flex-direction: row;
+}
+
+.content-container .content-brandName p {
+  margin-right: 10px;
+}
+
+.none {
+  display: none;
+}
+
+/* pagination */
+.pagination-container .pagination-list {
+  gap: 1rem;
+  justify-content: center;
+}
+
+/* header */
+.header-menu-wrapper .menu-list li {
+  margin-bottom: 0px !important;
+} 


### PR DESCRIPTION
홈 화면의 주종 별 상품 클릭 시 보여지는 페이지에서 다른 상품 나열 페이지들과 다르게 적용되었던 css를 수정하여 통일시킴.
기존 : 반응형 적용 시 상품들이 1줄로 보여지며 전반적인 수정이 적용되지 않았던 스타일
수정: category.css, event_page.css와 같이 반응형 적용 시 최소 2줄로 나열된 상품들이 유지되고 세부적으로 적용 했던 수정사항들도 동일하게 적용됨.